### PR TITLE
store cdata matrix as separate data elements for each column

### DIFF
--- a/@gifti/fieldnames.m
+++ b/@gifti/fieldnames.m
@@ -13,4 +13,6 @@ if numel(this) > 1, warning('Only handle scalar objects yet.'); end
 
 pfn = {'vertices' 'faces' 'normals' 'cdata' 'mat' 'labels' 'indices'};
 
-names = pfn(isintent(this,pfn));
+% cdata elements can occur multiple times; only return each fieldname
+% exactly once.
+names = unique(pfn(isintent(this,pfn)));

--- a/@gifti/save.m
+++ b/@gifti/save.m
@@ -169,19 +169,20 @@ end
 
 % DataArray
 %--------------------------------------------------------------------------
-for i=1:length(this.data)
+data=this.data;
+for i=1:length(data)
     fprintf(fid,'%s<DataArray',o(1));
     if def.offset
-        this.data{i}.attributes.ExternalFileOffset = num2str(def.offset);
+        data{i}.attributes.ExternalFileOffset = num2str(def.offset);
     end
-    fn = sort(fieldnames(this.data{i}.attributes));
+    fn = sort(fieldnames(data{i}.attributes));
     oo = repmat({o(5) '\n'},length(fn),1); oo{1} = '  '; oo{end} = '';
     for j=1:length(fn)
         if strcmp(fn{j},'ExternalFileName')
-            [p,f,e] = fileparts(this.data{i}.attributes.(fn{j}));
+            [p,f,e] = fileparts(data{i}.attributes.(fn{j}));
             attval = [f e];
         else
-            attval = this.data{i}.attributes.(fn{j});
+            attval = data{i}.attributes.(fn{j});
         end
         fprintf(fid,'%s%s="%s"%s',oo{j,1},...
                 fn{j},attval,sprintf(oo{j,2}));
@@ -191,26 +192,26 @@ for i=1:length(this.data)
     % MetaData
     %----------------------------------------------------------------------
     fprintf(fid,'%s<MetaData>\n',o(2));
-    for j=1:length(this.data{i}.metadata)
+    for j=1:length(data{i}.metadata)
         fprintf(fid,'%s<MD>\n',o(3));
         fprintf(fid,'%s<Name><![CDATA[%s]]></Name>\n',o(4),...
-            this.data{i}.metadata(j).name);
+            data{i}.metadata(j).name);
         fprintf(fid,'%s<Value><![CDATA[%s]]></Value>\n',o(4),...
-            this.data{i}.metadata(j).value);
+            data{i}.metadata(j).value);
         fprintf(fid,'%s</MD>\n',o(3));
     end
     fprintf(fid,'%s</MetaData>\n',o(2));
     
     % CoordinateSystemTransformMatrix
     %----------------------------------------------------------------------
-    for j=1:length(this.data{i}.space)
+    for j=1:length(data{i}.space)
         fprintf(fid,'%s<CoordinateSystemTransformMatrix>\n',o(2));
         fprintf(fid,'%s<DataSpace><![CDATA[%s]]></DataSpace>\n',o(3),...
-            this.data{i}.space(j).DataSpace);
+            data{i}.space(j).DataSpace);
         fprintf(fid,'%s<TransformedSpace><![CDATA[%s]]></TransformedSpace>\n',o(3),...
-            this.data{i}.space(j).TransformedSpace);
+            data{i}.space(j).TransformedSpace);
         fprintf(fid,'%s<MatrixData>%s</MatrixData>\n',o(3),...
-            sprintf('%f ',this.data{i}.space(j).MatrixData'));
+            sprintf('%f ',data{i}.space(j).MatrixData'));
         fprintf(fid,'%s</CoordinateSystemTransformMatrix>\n',o(2));
     end
     
@@ -219,22 +220,22 @@ for i=1:length(this.data)
     fprintf(fid,'%s<Data>',o(2));
     tp = getdict;
     try
-        tp = tp.(this.data{i}.attributes.DataType);
+        tp = tp.(data{i}.attributes.DataType);
     catch
         error('[GIFTI] Unknown DataType.');
     end
-    switch this.data{i}.attributes.Encoding
+    switch data{i}.attributes.Encoding
         case 'ASCII'
-            fprintf(fid, [tp.format ' '], this.data{i}.data);
+            fprintf(fid, [tp.format ' '], data{i}.data);
         case 'Base64Binary'
-            fprintf(fid,base64encode(typecast(this.data{i}.data(:),'uint8')));
+            fprintf(fid,base64encode(typecast(data{i}.data(:),'uint8')));
             % uses native machine format
         case 'GZipBase64Binary'
-            fprintf(fid,base64encode(zstream('C',typecast(this.data{i}.data(:),'uint8'))));
+            fprintf(fid,base64encode(zstream('C',typecast(data{i}.data(:),'uint8'))));
             % uses native machine format
         case 'ExternalFileBinary'
-            extfilename = this.data{i}.attributes.ExternalFileName;
-            dat = this.data{i}.data;
+            extfilename = data{i}.attributes.ExternalFileName;
+            dat = data{i}.data;
             if isa(dat,'file_array')
                 dat = subsref(dat,substruct('()',repmat({':'},1,numel(dat.dim))));
             end

--- a/@gifti/save.m
+++ b/@gifti/save.m
@@ -273,17 +273,18 @@ function data = get_gifti_data_vectorized(this)
 % gets the data from this.data. 
 % data elements with intent 'indices' or 'cdata' are converted to a list
 % of vector elements with RowMajorOrder, even if they are present as
-% matrices in this.data
+% matrices in this.data. It also ensures (by re-ordering, if necessary),
+% that data elements with intent 'indices' comes first.
 
 n=numel(this.data);
 
 data_cell=cell(1,n);
-[data_types,indices_to_vectorize]=isintent(this,{'indices','cdata'});
+[data_types,i_to_vectorize]=isintent(this,{'indices','cdata'});
 
 for i=1:n
     d=this.data{i};
 
-    data_type_index=find(i==indices_to_vectorize);
+    data_type_index=find(i==i_to_vectorize);
     if isempty(data_type_index)
         % no conversion needed
         data_cell{i}={d};
@@ -315,7 +316,12 @@ for i=1:n
     data_cell{i}=d_vec;
 end
 
-data=cat(2,data_cell{:});
+% ensure that data with indices comes first
+indices_pos=i_to_vectorize(data_types==1);
+indices_ordered=[indices_pos setdiff(1:n, indices_pos)];
+
+data_cell_ordered=data_cell(indices_ordered);
+data=cat(2,data_cell_ordered{:});
 
 
 %==========================================================================


### PR DESCRIPTION
the GIFTI standard requires that cdata (such as time series data) has Dimensionality=1 according to [1], page 36:

```
The functional file contains one or more DataArrays with Intent set to NIFTI_INTENT_NONE 
or one of the statistical intent values. Each DataArray has DataType set to NIFTI_TYPE_FLOAT32.
Dimensionality is one with the first dimension set to the number of nodes.
```

In the original code, the following produces an illegal GIFTI file that cannot be read by AFNI's ConvertDset:

```
s=struct();
s.cdata=randn(7,3);
g=gifti(s);
save(g,'myfile.gii')
```

because the DataArray has Dimensionality='2'.

This PR ensures that "cdata" and "indices" data are stored as column vectors.

In addition, it introduces two minor fixes:
- even if there are multiple data elements with intent 'cdata', the `fieldnames`function returns 'cdata' only once.
- if there is an 'indices' element, then when saving the file, it is the first element present. This is required per the GIFTI standard, page 19:
  
  For storing a subset of node data, a DataArray with intent NIFTI_INTENT_NODE_INDEX 
  may be used. In this case, the data array contains a list of node numbers and it should be 
  the first data array in the file. The remaining data arrays in the file that contain data 
  assigned to nodes must contain the same number of elements as the 
  NIFTI_INTENT_NODE_INDEX array.

[1] https://www.nitrc.org/frs/download.php/2871/GIFTI_Surface_Format.pdf
